### PR TITLE
opt-depend on default [squash]

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/init.lua
+++ b/init.lua
@@ -76,7 +76,7 @@ minetest.register_node("jumping:cushion", {
 	groups = {dig_immediate=2, disable_jump=1, fall_damage_add_percent=-100},
 })
 
--- register recipes if the default mod is present
+-- register recipes if the corresponding mods are present
 if minetest.get_modpath("default") then
 	minetest.register_craft({
 		output = "jumping:trampoline1",
@@ -85,7 +85,9 @@ if minetest.get_modpath("default") then
 			{"default:steel_ingot", "", "default:steel_ingot"}
 		}
 	})
+end
 
+if minetest.get_modpath("farming") and minetest.get_modpath("wool") then
 	minetest.register_craft({
 		output = "jumping:cushion",
 		recipe = {

--- a/init.lua
+++ b/init.lua
@@ -76,19 +76,22 @@ minetest.register_node("jumping:cushion", {
 	groups = {dig_immediate=2, disable_jump=1, fall_damage_add_percent=-100},
 })
 
-minetest.register_craft({
-	output = "jumping:trampoline1",
-	recipe = {
-		{"jumping:cushion", "jumping:cushion", "jumping:cushion"},
-		{"default:steel_ingot", "", "default:steel_ingot"}
-	}
-})
+-- register recipes if the default mod is present
+if minetest.get_modpath("default") then
+	minetest.register_craft({
+		output = "jumping:trampoline1",
+		recipe = {
+			{"jumping:cushion", "jumping:cushion", "jumping:cushion"},
+			{"default:steel_ingot", "", "default:steel_ingot"}
+		}
+	})
 
-minetest.register_craft({
-	output = "jumping:cushion",
-	recipe = {
-		{"farming:cotton", "group:wool", "farming:cotton"},
-		{"farming:cotton", "group:wool", "farming:cotton"},
-		{"farming:cotton", "farming:cotton", "farming:cotton"}
-	}
-})
+	minetest.register_craft({
+		output = "jumping:cushion",
+		recipe = {
+			{"farming:cotton", "group:wool", "farming:cotton"},
+			{"farming:cotton", "group:wool", "farming:cotton"},
+			{"farming:cotton", "farming:cotton", "farming:cotton"}
+		}
+	})
+end

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,1 @@
 name = jumping
-optional_depends = default

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,2 @@
 name = jumping
+optional_depends = default


### PR DESCRIPTION
This PR adds:
* Optional depends on `default` (recipes are disabled if not present)
* `mod.conf` with dependencies

Removed:
* deprecated `depends.txt`